### PR TITLE
Clean secrets, use env vars

### DIFF
--- a/DEPLOYMENT_COMPLETE.md
+++ b/DEPLOYMENT_COMPLETE.md
@@ -91,9 +91,9 @@ MarrakechDunes/
 ### Environment Variables
 ```bash
 # Production Configuration
-DATABASE_URL=mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/marrakech-tours
-JWT_SECRET=ct8B36w2JW68WY6ofFLarloQJxCXVQNcBofS0tM78767E69782944DABB
-SESSION_SECRET=FeU8jTYGmCars6u3qUX8uyMF5SkLxhkH9HrXv0rx162dcFGrf8TmfXEP27unxj0525rqj8w1uk
+DATABASE_URL=<YOUR_MONGO_URI>
+JWT_SECRET=<YOUR_JWT_SECRET>
+SESSION_SECRET=<YOUR_SESSION_SECRET>
 NODE_ENV=production
 PORT=5000
 ```

--- a/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -15,9 +15,9 @@
 ### 1. Environment Configuration
 ```bash
 # Required Environment Variables
-DATABASE_URL=mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/marrakech-tours
-JWT_SECRET=ct8B36w2JW68WY6ofFLarloQJxCXVQNcBofS0tM78767E69782944DABB
-SESSION_SECRET=FeU8jTYGmCars6u3qUX8uyMF5SkLxhkH9HrXv0rx162dcFGrf8TmfXEP27unxj0525rqj8w1uk
+DATABASE_URL=<YOUR_MONGO_URI>
+JWT_SECRET=<YOUR_JWT_SECRET>
+SESSION_SECRET=<YOUR_SESSION_SECRET>
 NODE_ENV=production
 PORT=5000
 ```
@@ -79,9 +79,9 @@ git push -u origin main
 
 3. **Environment Variables**
    ```
-   DATABASE_URL=mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/marrakech-tours
-   JWT_SECRET=ct8B36w2JW68WY6ofFLarloQJxCXVQNcBofS0tM78767E69782944DABB
-   SESSION_SECRET=FeU8jTYGmCars6u3qUX8uyMF5SkLxhkH9HrXv0rx162dcFGrf8TmfXEP27unxj0525rqj8w1uk
+   DATABASE_URL=<YOUR_MONGO_URI>
+   JWT_SECRET=<YOUR_JWT_SECRET>
+   SESSION_SECRET=<YOUR_SESSION_SECRET>
    NODE_ENV=production
    PORT=5000
    ```

--- a/render.yaml
+++ b/render.yaml
@@ -13,11 +13,11 @@ services:
       - key: PORT
         value: 10000
       - key: MONGO_URI
-        value: mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/marrakech-tours
+        value: <YOUR_MONGO_URI>
       - key: SESSION_SECRET
-        value: FeU8jTYGmCars6u3qUX8uyMF5SkLxhkH9HrXv0rx162dcFGrf8TmfXEP27unxj0525rqj8w1uk
+        value: <YOUR_SESSION_SECRET>
       - key: JWT_SECRET
-        value: ct8B36w2JW68WY6ofFLarloQJxCXVQNcBofS0tM78767E69782944DABB
+        value: <YOUR_JWT_SECRET>
     disk:
       name: marrakech-assets
       mountPath: /app/attached_assets

--- a/replit.md
+++ b/replit.md
@@ -208,7 +208,7 @@ Preferred communication style: Simple, everyday language.
 - **MongoDB Atlas Integration**: Implemented pure MongoDB-only storage system for MarrakechDunes booking platform
   - Removed all PostgreSQL dependencies and fallback systems per user requirement
   - Configured Mongoose with proper schema definitions for Users, Activities, Bookings, Reviews, and Audit Logs
-  - MongoDB connection string: mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/marrakech-tours
+  - MongoDB connection string: <YOUR_MONGO_URI>
   - Session management updated to use connect-mongo for MongoDB session storage
   - Application successfully serving on port 5000 with pure MongoDB architecture
   - **IP Whitelisting Required**: Replit server IP 35.247.74.178 must be added to MongoDB Atlas Network Access for full connectivity

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
@@ -63,10 +64,10 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
+  // serve the app on the configured PORT (defaults to 5000)
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const port = 5000;
+  const port = Number(process.env.PORT) || 5000;
   server.listen({
     port,
     host: "0.0.0.0",

--- a/server/security-middleware.ts
+++ b/server/security-middleware.ts
@@ -192,11 +192,11 @@ export const adminAuditLog = (req: Request, res: Response, next: NextFunction) =
 // Session security configuration
 export const sessionSecurity = {
   name: 'marrakech.session',
-  secret: process.env.SESSION_SECRET || 'FeU8jTYGmCars6u3qUX8uyMF5SkLxhkH9HrXv0rx162dcFGrf8TmfXEP27unxj0525rqj8w1uk',
+  secret: process.env.SESSION_SECRET || '',
   resave: false,
   saveUninitialized: false,
   store: MongoStore.create({
-    mongoUrl: process.env.MONGO_URI || 'mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/',
+    mongoUrl: process.env.MONGO_URI || '',
     dbName: 'marrakech-tours',
     touchAfter: 24 * 3600,
     ttl: 24 * 60 * 60 // 24 hours

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -15,8 +15,8 @@ import type {
   ReviewWithActivity,
 } from "../shared/schema";
 
-// MongoDB connection string - ensure proper format
-const DATABASE_URL = process.env.DATABASE_URL || 'mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/marrakech-tours';
+// MongoDB connection string
+const DATABASE_URL = process.env.DATABASE_URL || '';
 
 // In-memory storage for fallback when MongoDB is unavailable
 const inMemoryData = {


### PR DESCRIPTION
## Summary
- use `dotenv` in server start script
- configure PORT from `process.env`
- remove hardcoded connection strings and secrets
- scrub production docs of real secrets

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6862840611588331bafa81dbda1d3b0a