### PR TITLE
Fix server build and include shared dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4546,7 +4546,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -5016,6 +5015,15 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minipass": {
       "version": "7.1.2",
@@ -6373,6 +6381,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -6550,6 +6567,20 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -7423,6 +7454,7 @@
         "helmet": "^8.1.0",
         "mongoose": "^8.16.1",
         "nanoid": "^5.1.5",
+        "tsconfig-paths": "^4.2.0",
         "zod": "^3.24.2"
       },
       "devDependencies": {

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,6 +9,7 @@ FROM node:18-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY shared ./shared
 RUN npm run build
 
 # Development image with hot reload
@@ -17,6 +18,7 @@ WORKDIR /app
 ENV NODE_ENV=development
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY shared ./shared
 EXPOSE 5000
 CMD ["npm", "run", "dev"]
 
@@ -26,6 +28,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=builder /app/dist ./dist
 COPY package*.json ./
+COPY shared ./shared
 RUN npm install --omit=dev
 EXPOSE 5000
 CMD ["node", "dist/index.js"]

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import "tsconfig-paths/register";
 import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "NODE_ENV=development tsx index.ts",
-    "build": "esbuild index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "esbuild index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:lightningcss",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc --noEmit"
   },
@@ -22,7 +22,8 @@
     "mongoose": "^8.16.1",
     "nanoid": "^5.1.5",
     "zod": "^3.24.2",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
     "@types/node": "20.16.11",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -15,12 +15,12 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@shared/*": ["../shared/*"]
+      "@shared/*": ["./shared/*"]
     }
   },
   "include": [
     "**/*.ts",
-    "../shared/**/*.ts"
+    "./shared/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- avoid bundling lightningcss during server build
- install tsconfig-paths and register it in the server entry
- adjust server tsconfig for `@shared` alias
- ensure Dockerfile copies the shared directory in all stages

## Testing
- `npm --workspace=client run build`
- `npm --workspace=server run build`


------
https://chatgpt.com/codex/tasks/task_e_6866591dbc9883318110ff39c6f0c37a