### PR TITLE
Fix build issues and server types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.11",
         "@types/node": "^20.10.0",
+        "autoprefixer": "^10.4.21",
         "concurrently": "^8.2.2",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
@@ -2796,6 +2797,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect-mongo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/connect-mongo/-/connect-mongo-3.1.6.tgz",
+      "integrity": "sha512-g/zB46xByucc4PJEw8zzTMtlQCAJBIOqqYfh3BDgps1xLahQZMa8925XXAhsa6eJ9YSSpE54UZc+34r7PdVRqw==",
+      "deprecated": "This is a stub types definition. connect-mongo provides its own type definitions, so you do not need this installed.",
+      "license": "MIT",
+      "dependencies": {
+        "connect-mongo": "*"
       }
     },
     "node_modules/@types/d3-array": {
@@ -9081,6 +9092,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@types/bcrypt": "^5.0.2",
+        "@types/connect-mongo": "^3.1.3",
         "@types/express": "4.17.21",
         "@types/express-session": "^1.18.0",
         "@types/mongoose": "^5.11.96",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",
+    "autoprefixer": "^10.4.21",
     "@types/node": "^20.10.0",
     "concurrently": "^8.2.2",
     "copyfiles": "^2.4.1",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",
     "@types/mongoose": "^5.11.96",
+    "@types/connect-mongo": "^3.1.3",
     "bcrypt": "^6.0.0",
     "connect-mongo": "^5.1.0",
     "dotenv": "^16.3.1",

--- a/server/src/security-middleware.ts
+++ b/server/src/security-middleware.ts
@@ -13,7 +13,7 @@ export const authRateLimit = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) => {
+  skip: (req: Request) => {
     // Skip rate limiting in development
     return process.env.NODE_ENV === 'development';
   }
@@ -29,7 +29,7 @@ export const adminApiRateLimit = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) => {
+  skip: (req: Request) => {
     // Skip rate limiting in development
     return process.env.NODE_ENV === 'development';
   }
@@ -45,7 +45,7 @@ export const generalApiRateLimit = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) => {
+  skip: (req: Request) => {
     // Skip rate limiting in development
     return process.env.NODE_ENV === 'development';
   }


### PR DESCRIPTION
## Summary
- ensure autoprefixer is available at the root
- install missing `@types/connect-mongo`
- add explicit `Request` type for rate limiter callbacks

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876875235408331a5a9a2a38b519297