### PR TITLE
Fix Docker workspaces and border color

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
+COPY client/package*.json ./client/
+COPY server/package*.json ./server/
 RUN npm install
 
 # ==========================

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -28,7 +28,9 @@ const config: Config = {
           800: '#7B341E',
           900: '#652B19',
         },
-        border: "hsl(var(--border))",
+        border: {
+          DEFAULT: "hsl(var(--border))",
+        },
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,7 +41,9 @@ export default {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
-        border: "hsl(var(--border))",
+        border: {
+          DEFAULT: "hsl(var(--border))",
+        },
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         chart: {


### PR DESCRIPTION
## Summary
- ensure Docker installs workspace deps before build
- expose `colors.border` in Tailwind configs

## Testing
- `npm run build:client`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68769fe87eb08331bf6b6f86acb5d17e