### PR TITLE
Fix Node ESM imports for server

### DIFF
--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -4,7 +4,7 @@ import session from "express-session";
 import MongoStore from "connect-mongo";
 import bcrypt from "bcrypt";
 import { storage } from "./storage.js";
-import { insertBookingSchema, insertReviewSchema } from "@shared/schema";
+import { insertBookingSchema, insertReviewSchema } from "@shared/schema.js";
 import { whatsappService } from "./whatsapp-service.js";
 import { z } from "zod";
 import {

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -13,7 +13,7 @@ import type {
   InsertReview,
   BookingWithActivity,
   ReviewWithActivity,
-} from "@shared/schema";
+} from "@shared/schema.js";
 
 // MongoDB connection string. Support DATABASE_URL, MONGODB_URI, or legacy MONGO_URI
 const DATABASE_URL =

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,6 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "..",


### PR DESCRIPTION
## Summary
- add `.js` extension to shared imports in server code
- allow importing TS extensions in `server/tsconfig.json`
- make sure the shared folder is included

## Testing
- `npx tsc -p server/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6876a5d925d483318c65d6bae91ec04e