### PR TITLE
Fix ESM import extensions after build

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,7 +8,6 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/scripts/fix-import-extensions.js
+++ b/scripts/fix-import-extensions.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, '../server/dist');
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (fs.statSync(full).isDirectory()) {
+      walk(full);
+    } else if (entry.endsWith('.js')) {
+      fixFile(full);
+    }
+  }
+}
+
+function fixFile(file) {
+  let content = fs.readFileSync(file, 'utf8');
+  // Replace static imports
+  content = content.replace(/(from\s+['"])(\.\.?(?:\/[^'";]+)+?)(?:(?:\.ts)?)(['"])/g, (m, p1, p2, p3) => {
+    if (p2.endsWith('.js') || p2.endsWith('.json')) return m;
+    return `${p1}${p2}.js${p3}`;
+  });
+  // Replace dynamic imports
+  content = content.replace(/(import\(\s*['"])(\.\.?(?:\/[^'";]+)+?)(?:(?:\.ts)?)(['"]\s*\))/g, (m, p1, p2, p3) => {
+    if (p2.endsWith('.js') || p2.endsWith('.json')) return m;
+    return `${p1}${p2}.js${p3}`;
+  });
+  fs.writeFileSync(file, content);
+}
+
+walk(distDir);
+

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "dist/server/src/index.js",
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx watch src/index.ts",
-    "build": "tsc --outDir dist && tscpaths -p tsconfig.json -s .. -o ./dist",
+    "build": "tsc --outDir dist && tscpaths -p tsconfig.json -s .. -o ./dist && node ../scripts/fix-import-extensions.js",
     "start": "NODE_ENV=production node dist/server/src/index.js",
     "check": "tsc --noEmit"
   },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,8 @@
 import "dotenv/config";
 import path from "path";
 import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes.js";
-import { setupVite, serveStatic, log } from "./vite-runtime.js";
+import { registerRoutes } from "./routes";
+import { setupVite, serveStatic, log } from "./vite-runtime";
 import { fileURLToPath } from "url";
 // Initialize application with MongoDB
 console.log('Initializing MarrakechDunes with MongoDB Atlas...');

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -3,9 +3,9 @@ import { createServer, type Server } from "http";
 import session from "express-session";
 import MongoStore from "connect-mongo";
 import bcrypt from "bcrypt";
-import { storage } from "./storage.js";
-import { insertBookingSchema, insertReviewSchema } from "@shared/schema.js";
-import { whatsappService } from "./whatsapp-service.js";
+import { storage } from "./storage";
+import { insertBookingSchema, insertReviewSchema } from "@shared/schema";
+import { whatsappService } from "./whatsapp-service";
 import { z } from "zod";
 import {
   authRateLimit,
@@ -18,7 +18,7 @@ import {
   securityHeaders,
   adminAuditLog,
   sessionSecurity
-} from "./security-middleware.js";
+} from "./security-middleware";
 
 // Types for session data
 declare module 'express-session' {

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -13,7 +13,7 @@ import type {
   InsertReview,
   BookingWithActivity,
   ReviewWithActivity,
-} from "@shared/schema.js";
+} from "@shared/schema";
 
 // MongoDB connection string. Support DATABASE_URL, MONGODB_URI, or legacy MONGO_URI
 const DATABASE_URL =


### PR DESCRIPTION
## Summary
- strip .js extensions from server TypeScript sources
- postprocess built files to add `.js` extension
- call the postbuild script from server `package.json`
- remove deprecated `allowImportingTsExtensions` option

## Testing
- `npm run build:server`
- `npm --workspace server run check`


------
https://chatgpt.com/codex/tasks/task_e_6876aca2da6883318f2c64bde48e94e5