### PR TITLE
Fix Docker and env placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,20 @@
 # === Database Configuration ===
-MONGODB_URI=mongodb+srv://<username>:<password>@cluster.mongodb.net/<database>
+MONGODB_URI=<your-mongo-uri>
 
 # === Authentication & Security ===
-SESSION_SECRET=your-session-secret
-JWT_SECRET=your-jwt-secret
-ADMIN_DEFAULT_PASSWORD=change-me
+SESSION_SECRET=<your-session-secret>
+JWT_SECRET=<your-jwt-secret>
+ADMIN_DEFAULT_PASSWORD=<your-admin-password>
 
 # === Server Configuration ===
 NODE_ENV=production
 PORT=5000
 
 # === WhatsApp Notification (Optional) ===
-WHATSAPP_API_KEY=your-whatsapp-api-key
-WHATSAPP_PHONE_NUMBER=your-whatsapp-phone-number
+WHATSAPP_API_KEY=<your-whatsapp-api-key>
+WHATSAPP_PHONE_NUMBER=<whatsapp-phone-number>
 
 # === Admin Contact Numbers ===
-ADMIN_PHONE_AHMED=+212600623630
-ADMIN_PHONE_YAHIA=+212693323368
-ADMIN_PHONE_NADIA=+212654497354
+ADMIN_PHONE_AHMED=<phone-number>
+ADMIN_PHONE_YAHIA=<phone-number>
+ADMIN_PHONE_NADIA=<phone-number>

--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,10 @@
 services:
   - type: web
     name: marrakech-dunes-backend
-    env: node
+    env: docker
     plan: starter
     region: frankfurt
-    buildCommand: cd server && npm install && npm run build
-    startCommand: cd server && npm start
+    dockerfilePath: Dockerfile
     healthCheckPath: /api/health
     envVars:
       - key: NODE_ENV
@@ -13,7 +12,7 @@ services:
       - key: PORT
         value: 10000
       - key: MONGODB_URI
-        sync: false
+        value: <your-mongo-uri>
       - key: SESSION_SECRET
         sync: false
       - key: JWT_SECRET

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,12 +1,9 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
-
-const viteLogger = createLogger();
 
 export function log(message: string, source = "express") {
   const formattedTime = new Date().toLocaleTimeString("en-US", {
@@ -20,6 +17,9 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
+  const { createServer: createViteServer, createLogger } = await import("vite");
+  const viteLogger = createLogger();
+
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },


### PR DESCRIPTION
## Summary
- sanitize `.env.example` secrets and unify MongoDB placeholders
- update `render.yaml` for Docker deployment
- refine multi-stage Dockerfile and dynamic healthcheck
- fix dev server imports for Vite

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888b00e9a4c8331b7985a3bbc9e7d9b