### PR TITLE
Fix server Docker build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY server/package*.json ./
 RUN npm install --legacy-peer-deps
 COPY server/ ./
 COPY shared/ ../shared/
+COPY vite.config.* ../
 RUN npm run build
 
 # Stage 3: Production runtime


### PR DESCRIPTION
## Summary
- copy `vite.config.*` when building the server image so `../vite.config` resolves correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888fc4402d48331a3f1ec4c9360692b