### PR TITLE
Ensure attached assets available in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,5 @@ server/dist
 .gitignore
 Dockerfile
 render.yaml
+# attached_assets
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app/client
 COPY client/package*.json ./
 RUN npm install --legacy-peer-deps
 COPY client/ ./
+COPY attached_assets /app/attached_assets
 RUN npm run build
 
 # Stage 2: Build the server


### PR DESCRIPTION
## Summary
- include `attached_assets` in Docker context
- copy assets into client-builder stage so Vite can see them

## Testing
- `npm run check` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6889028ae33083318d5f01faa0b1fc45