### PR TITLE
Fix Docker client build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app/client
 COPY client/package*.json ./
 RUN npm install --legacy-peer-deps
 COPY client/ ./
+COPY shared/ ../shared/
 COPY attached_assets /app/attached_assets
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- copy `shared` into client build stage so Vite can resolve schema imports

## Testing
- `npm run build`
- `cd client && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688909ffc4e883318a80c681b8d47129