### PR TITLE
Fix client build dependency and docker configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,5 @@ server/dist
 .gitignore
 Dockerfile
 render.yaml
-# attached_assets
+attached_assets
 

--- a/render.yaml
+++ b/render.yaml
@@ -9,8 +9,6 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
-      - key: PORT
-        value: 10000
       - key: MONGODB_URI
         value: <your-mongo-uri>
       - key: SESSION_SECRET

--- a/replit.md
+++ b/replit.md
@@ -208,7 +208,7 @@ Preferred communication style: Simple, everyday language.
 - **MongoDB Atlas Integration**: Implemented pure MongoDB-only storage system for MarrakechDunes booking platform
   - Removed all PostgreSQL dependencies and fallback systems per user requirement
   - Configured Mongoose with proper schema definitions for Users, Activities, Bookings, Reviews, and Audit Logs
-  - MongoDB connection string: mongodb+srv://hamzacharafeddine77:FxUfGGZ8VRyflrGW@marrakechtours-cluster.cvyntkb.mongodb.net/marrakech-tours
+  - MongoDB connection string: <REDACTED>
   - Session management updated to use connect-mongo for MongoDB session storage
   - Application successfully serving on port 5000 with pure MongoDB architecture
   - **IP Whitelisting Required**: Replit server IP 35.247.74.178 must be added to MongoDB Atlas Network Access for full connectivity


### PR DESCRIPTION
## Summary
- ensure `zod` is installed for the client build
- ignore `attached_assets` in Docker builds
- clean up `render.yaml` and let Render choose the port
- redact MongoDB URI from docs

## Testing
- `cd client && npm run build`
- `cd server && npm run build`
- *(docker build not run: docker unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688b45396f0c8331af428852753765d3