### PR TITLE
feat: bundle zod and enable node types

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["node", "vite/client"],
     
     /* Linting */
     "strict": true,

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -5,7 +5,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,21 +1,27 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+// __dirname is not available in ESM, recreate it for use in aliases below
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-       '@assets': path.resolve(__dirname, './public/assets'),
+      '@assets': path.resolve(__dirname, './public/assets'),
       '@shared': path.resolve(__dirname, '../shared'),
     },
+  },
+  optimizeDeps: {
+    include: ['zod'],
   },
   build: {
     outDir: 'dist',
     sourcemap: false,
     rollupOptions: {
-       external: ['zod'], 
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom'],


### PR DESCRIPTION
## Summary
- bundle zod in client build and pre-bundle for dev
- fix vite config to work in ESM and add node type definitions
- expose Node types to frontend TypeScript

## Testing
- `npm --prefix client run check` *(fails: unused variable errors)*
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_688e54f37ba083318b1aa6b3cf7d4af4