### PR TITLE
fix: remove duplicate Vite alias and ensure zod install

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@assets': path.resolve(__dirname, './public/assets'),
-      '@assets': path.resolve(__dirname, './public/assets'),
       '@shared': path.resolve(__dirname, '../shared'),
     },
   },


### PR DESCRIPTION
## Summary
- remove duplicate `@assets` alias from `client/vite.config.ts`
- ensure `zod` dependency is installed for shared schemas

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f53c1ee088331a80eeb629e7f063e