### PR TITLE
build: ensure monorepo builds on vercel and render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,31 @@
-# --- Base Stage ---
-FROM node:20-slim AS base
-WORKDIR /app
-COPY package*.json ./
-
-# Install only production dependencies by default
-RUN npm ci --only=production --legacy-peer-deps
-
-# --- Build Stage ---
+# Multi-stage build for monorepo (client + server)
 FROM node:20-slim AS build
 WORKDIR /app
+
+# Install dependencies including devDeps for both workspaces
+COPY package*.json ./
+COPY server/package*.json server/
+COPY client/package*.json client/
+RUN npm ci --legacy-peer-deps
+
+# Copy source and build
 COPY . .
-
-# Install ALL dependencies (including vite + devDeps) for build
-RUN npm install --legacy-peer-deps
-
-# Compile TypeScript for server and shared
 RUN npm run build
 
-# --- Production Stage ---
+# Production image
 FROM node:20-slim AS prod
 WORKDIR /app
 
-# Copy only built output & necessary files
+# Copy compiled output
 COPY --from=build /app/dist ./dist
-COPY package*.json ./
 
-# Install only production dependencies for runtime
+# Install only production dependencies for the server
+COPY server/package.json ./package.json
+COPY server/package-lock.json ./package-lock.json
 RUN npm ci --only=production --legacy-peer-deps
 
-# Use port from environment or default to 3000
-ENV PORT=${PORT:-3000}
-EXPOSE ${PORT}
+ENV PORT=3000
+EXPOSE 3000
 
-# Start the server
-CMD ["node", "dist/index.js"]
+CMD ["node", "dist/server/index.js"]
+

--- a/client/src/components/activity-rating.tsx
+++ b/client/src/components/activity-rating.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 
 interface ActivityRatingProps {
   activityId: string;

--- a/client/src/components/booking-form-modal.tsx
+++ b/client/src/components/booking-form-modal.tsx
@@ -29,7 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { Plus, Calendar, Users } from "lucide-react";
 
 const bookingFormSchema = z.object({

--- a/client/src/components/payment-management.tsx
+++ b/client/src/components/payment-management.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { 
   Banknote, 
   CheckCircle, 

--- a/client/src/components/review-form.tsx
+++ b/client/src/components/review-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { insertReviewSchema } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { useLanguage } from "@/hooks/useLanguage";
 import { Button } from "@/components/ui/button";

--- a/client/src/components/review-list.tsx
+++ b/client/src/components/review-list.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Star, User, Calendar, CheckCircle } from "lucide-react";
 import { useLanguage } from "@/hooks/useLanguage";
 import type { ReviewWithActivity } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 
 interface ReviewListProps {
   activityId?: string;

--- a/client/src/hooks/use-security.tsx
+++ b/client/src/hooks/use-security.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { useToast } from '@/hooks/use-toast';
-import { apiRequest } from '@/lib/queryClient';
+import { apiRequest } from '@/lib/api';
 
 interface SecurityContext {
   isSecureConnection: boolean;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,33 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL || "";
+
+function withBase(url: string) {
+  return url.startsWith("http") ? url : `${API_BASE_URL}${url}`;
+}
+
+async function throwIfResNotOk(res: Response) {
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
+}
+
+export async function apiRequest(
+  method: string,
+  url: string,
+  data?: unknown,
+): Promise<Response> {
+  const res = await fetch(withBase(url), {
+    method,
+    headers: data ? { "Content-Type": "application/json" } : {},
+    body: data ? JSON.stringify(data) : undefined,
+    credentials: "include",
+  });
+
+  await throwIfResNotOk(res);
+  return res;
+}
+
+export function apiUrl(path: string) {
+  return withBase(path);
+}
+

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,10 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
-
-const API_BASE_URL = import.meta.env.VITE_API_URL || "";
-
-function withBase(url: string) {
-  return url.startsWith("http") ? url : `${API_BASE_URL}${url}`;
-}
+import { apiUrl } from "./api";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -13,29 +8,13 @@ async function throwIfResNotOk(res: Response) {
   }
 }
 
-export async function apiRequest(
-  method: string,
-  url: string,
-  data?: unknown | undefined,
-): Promise<Response> {
-  const res = await fetch(withBase(url), {
-    method,
-    headers: data ? { "Content-Type": "application/json" } : {},
-    body: data ? JSON.stringify(data) : undefined,
-    credentials: "include",
-  });
-
-  await throwIfResNotOk(res);
-  return res;
-}
-
 type UnauthorizedBehavior = "returnNull" | "throw";
 export const getQueryFn: <T>(options: {
   on401: UnauthorizedBehavior;
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(withBase(queryKey[0] as string), {
+    const res = await fetch(apiUrl(queryKey[0] as string), {
       credentials: "include",
     });
 

--- a/client/src/pages/admin/ceo-dashboard.tsx
+++ b/client/src/pages/admin/ceo-dashboard.tsx
@@ -34,7 +34,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import SuperAdminRoute from "@/components/superadmin-route";
 

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -14,7 +14,7 @@ import { WhatsAppNotificationPanel } from "@/components/whatsapp-notification-pa
 import SystemHealthMonitor from "@/components/system-health-monitor";
 import { useState } from "react";
 import type { BookingWithActivity, ActivityType, AuditLogType } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 
 export default function AdminDashboard() {
   const { user } = useAuth();

--- a/client/src/pages/admin/login.tsx
+++ b/client/src/pages/admin/login.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { useLocation } from "wouter";
 import { useLanguage } from "@/hooks/useLanguage";
 

--- a/client/src/pages/admin/performance-dashboard.tsx
+++ b/client/src/pages/admin/performance-dashboard.tsx
@@ -29,7 +29,7 @@ import {
   Settings,
   Wrench
 } from 'lucide-react';
-import { apiRequest } from '@/lib/queryClient';
+import { apiRequest } from '@/lib/api';
 
 interface PerformanceMetrics {
   responseTime: {

--- a/client/src/pages/booking-fixed.tsx
+++ b/client/src/pages/booking-fixed.tsx
@@ -4,7 +4,7 @@ import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { ActivityType } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import Navbar from "@/components/navbar";
 import Footer from "@/components/footer";

--- a/client/src/pages/booking-new.tsx
+++ b/client/src/pages/booking-new.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { ActivityType } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import Navbar from "@/components/navbar";
 import Footer from "@/components/footer";

--- a/client/src/pages/booking.tsx
+++ b/client/src/pages/booking.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { ActivityType, insertBookingSchema } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { sendWhatsAppBooking } from "@/lib/whatsapp";
 import Navbar from "@/components/navbar";

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -36,6 +36,9 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      fs: {
+        allow: ['..'],
+      },
       port: 3000,
       proxy: {
         '/api': {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/server/index.js",
     "check": "tsc --noEmit"
   },
   "dependencies": {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,7 +6,7 @@ import bcrypt from "bcrypt";
 import { storage } from "./storage";
 import { insertBookingSchema, insertReviewSchema, insertActivitySchema } from "@shared/schema";
 import { whatsappService } from "./whatsapp-service";
-import { z, ZodError } from "zod";
+import { z } from "zod";
 import {
   authRateLimit,
   adminApiRateLimit,
@@ -213,7 +213,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       res.status(201).json(booking);
     } catch (error: unknown) {
-      if (error instanceof ZodError) {
+      if (error instanceof z.ZodError) {
         return res.status(400).json({ message: "Validation error" });
       }
       console.error("Error creating booking:", error);
@@ -563,7 +563,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.status(201).json(activity);
     } catch (error: unknown) {
-      if (error instanceof ZodError) {
+      if (error instanceof z.ZodError) {
         return res.status(400).json({ message: "Validation error" });
       }
       console.error("Error creating activity:", error);
@@ -587,7 +587,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(activity);
     } catch (error: unknown) {
-      if (error instanceof ZodError) {
+      if (error instanceof z.ZodError) {
         return res.status(400).json({ message: "Validation error" });
       }
       console.error("Error updating activity:", error);
@@ -644,10 +644,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const review = await storage.createReview(validatedData);
       res.status(201).json(review);
     } catch (error: unknown) {
-      if (error instanceof ZodError) {
+      if (error instanceof z.ZodError) {
         return res.status(400).json({ 
           message: "Validation error", 
-          errors: error.errors 
+          errors: error.issues
         });
       }
       console.error("Error creating review:", error);

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -12,21 +12,23 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "outDir": "./dist",
-    "rootDir": ".",
-    "baseUrl": ".",
+    "outDir": "../dist",
+    "rootDir": "..",
+    "baseUrl": "..",
     "paths": {
-      "@shared/*": ["../shared/*"]
+      "@shared/*": ["shared/*"]
     }
-    // Removed: "allowImportingTsExtensions"
   },
   "include": [
-    "**/*.ts",
+    "./**/*.ts",
     "../shared/**/*.ts"
   ],
   "exclude": [
     "node_modules",
-    "dist",
-    "../vite.config.ts"  // Explicitly exclude vite config
+    "../client",
+    "../dist",
+    "../client/**",
+    "vite.config.ts",
+    "../vite.config.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- compile backend and shared code from a single TypeScript config
- add API helper and update client to use base URL from `VITE_API_URL`
- improve Docker and Vite configs for workspace builds

## Testing
- `npm run build --workspace=server`
- `npm run build --workspace=client`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68909ecd5d448331ac003bae062990ae