### PR TITLE
fix: allow cross-domain sessions

### DIFF
--- a/client/src/hooks/use-security.tsx
+++ b/client/src/hooks/use-security.tsx
@@ -60,8 +60,9 @@ export function SecurityProvider({ children }: { children: ReactNode }) {
   // Monitor rate limit headers from API responses
   useEffect(() => {
     const originalFetch = window.fetch;
-    window.fetch = async (...args) => {
-      const response = await originalFetch(...args);
+    window.fetch = async (input: RequestInfo, init?: RequestInit) => {
+      // Always include credentials with API requests
+      const response = await originalFetch(input, { credentials: 'include', ...init });
       const remaining = response.headers.get('X-RateLimit-Remaining');
       if (remaining) {
         setRateLimitRemaining(parseInt(remaining));

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || "";
+// Base URL for API requests coming from environment
+const API_BASE_URL = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
 
 function withBase(url: string) {
   return url.startsWith("http") ? url : `${API_BASE_URL}${url}`;

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,9 +17,17 @@ console.log("Initializing MarrakechDunes with MongoDB Atlas...");
 
 const app: Express = express();
 
+// Allow requests from the configured client domain(s) and include credentials
+const allowedOrigins = (process.env.CLIENT_URL || "").split(",").map(o => o.trim()).filter(Boolean);
 app.use(
   cors({
-    origin: process.env.CLIENT_URL,
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
     credentials: true,
   })
 );
@@ -35,7 +43,8 @@ if (!process.env.SESSION_SECRET) {
 }
 
 // Middleware setup
-app.set("trust proxy", true);
+// Trust the first proxy (Render/Vercel) so secure cookies work over HTTPS
+app.set("trust proxy", 1);
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 

--- a/server/security-middleware.ts
+++ b/server/security-middleware.ts
@@ -227,8 +227,10 @@ export const sessionSecurity = {
   resave: false,
   saveUninitialized: false,
   store: createSessionStore(),
+  // Ensure secure cookies and proper proxy handling in production
+  proxy: process.env.NODE_ENV === 'production',
   cookie: {
-    secure: true,
+    secure: process.env.NODE_ENV === 'production',
     httpOnly: true, // Prevent XSS
     maxAge: 24 * 60 * 60 * 1000, // 24 hours
     sameSite: 'none' as const,


### PR DESCRIPTION
## Summary
- expand CORS to use CLIENT_URL env and allow credentials
- secure session cookies for HTTPS deployments
- send credentials with frontend fetches and use env API base

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check --workspace=server`
- `npm run check --workspace=client` *(fails: TypeScript errors about unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_6891f0230e4083318d5786b60afe49d4