### PR TITLE
fix: deployment configs and asset handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ jspm_packages/
 dist/
 build/
 client/dist/
+client/public/attached_assets/
 .next/
 .nuxt/
 .vuepress/dist

--- a/README.md
+++ b/README.md
@@ -37,3 +37,33 @@ npm run dev
 # 3. Start backend (in server/)
 cd server
 npm run dev
+
+```
+
+## 🚀 Deployment Checklist
+
+### Render (Backend)
+1. Set environment variables: `MONGODB_URI`, `SESSION_SECRET`, `JWT_SECRET`, `ADMIN_DEFAULT_PASSWORD`, and `CLIENT_URL` (comma separated list of frontend URLs).
+2. Deploy the repo and ensure the `/attached_assets` folder is present.
+3. After deployment, review Render logs for MongoDB, CORS, or 404 errors.
+
+### Vercel (Frontend)
+1. Set the environment variable `VITE_API_URL` to your Render backend URL.
+2. The build step runs `scripts/check-attached-assets.cjs` to copy `/attached_assets` into `client/public/attached_assets`.
+3. After deployment, verify images load and clear the Vercel cache when assets change.
+
+### Verifying Deployment
+Run the helper script to check API endpoints and static assets:
+
+```bash
+node scripts/check-deployment.mjs
+```
+
+Test CORS headers manually:
+
+```bash
+curl -I -H "Origin: https://your-frontend.vercel.app" \
+  https://your-backend.onrender.com/api/health
+```
+
+Always review backend and frontend logs after each deploy to catch MongoDB, CORS, or 404 errors early.

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,2 @@
+# Base URL of the API the frontend should call
 VITE_API_URL=https://marrakech-dunes-backend.onrender.com

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -7,17 +7,16 @@ export function cn(...inputs: ClassValue[]) {
 
 export function getAssetUrl(path: string): string {
   if (!path) return "/assets/placeholder.jpg";
-  
-  
- // Already an absolute asset path
+  // Already an absolute asset path
   if (path.startsWith('/attached_assets/') || path.startsWith('/assets/')) {
+    return path;
   }
-  
+
   // Handle other asset paths
   if (path.startsWith('/')) {
     return path;
   }
-  
+
   // Default fallback
   return `/assets/${path}`;
 }

--- a/scripts/check-attached-assets.cjs
+++ b/scripts/check-attached-assets.cjs
@@ -2,72 +2,20 @@ const fs = require('fs');
 const path = require('path');
 
 const projectRoot = path.resolve(__dirname, '..');
-const srcDir = path.join(projectRoot, 'client', 'src');
-const publicAssetsDir = path.join(projectRoot, 'client', 'public', 'assets');
 const attachedDir = path.join(projectRoot, 'attached_assets');
-
-function walk(dir, files = []) {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const res = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      walk(res, files);
-    } else {
-      files.push(res);
-    }
-  }
-  return files;
-}
-
-function collectReferencedAssets() {
-  const result = new Set();
-  const files = walk(srcDir);
-  const assetRegex = /["'`](?:\/assets\/|@assets\/)([^"'`$]+)["'`]/g;
-  const attachedRegex = /["'`]\/attached_assets\/([^"'`]+)["'`]/g;
-  for (const file of files) {
-    if (!file.endsWith('.ts') && !file.endsWith('.tsx')) continue;
-    const content = fs.readFileSync(file, 'utf8');
-    let match;
-    while ((match = assetRegex.exec(content))) {
-      result.add(match[1]);
-    }
-    while ((match = attachedRegex.exec(content))) {
-      result.add(match[1]);
-    }
-  }
-  return Array.from(result).filter(a => !a.includes('placeholder') && !a.includes('$'));
-}
+const publicDir = path.join(projectRoot, 'client', 'public', 'attached_assets');
 
 function copyAttachedAssets() {
   if (!fs.existsSync(attachedDir)) {
     console.warn('No attached_assets directory found, skipping copy.');
     return;
   }
-  if (!fs.existsSync(publicAssetsDir)) {
-    fs.mkdirSync(publicAssetsDir, { recursive: true });
-  }
+
+  fs.mkdirSync(publicDir, { recursive: true });
   for (const file of fs.readdirSync(attachedDir)) {
-    const src = path.join(attachedDir, file);
-    const dest = path.join(publicAssetsDir, file);
-    try {
-      fs.copyFileSync(src, dest);
-    } catch (err) {
-      console.warn(`Failed to copy ${file}: ${err.message}`);
-    }
+    fs.copyFileSync(path.join(attachedDir, file), path.join(publicDir, file));
   }
+  console.log('Copied attached_assets to client/public/attached_assets');
 }
 
-function checkMissingAssets(referenced) {
-  const missing = [];
-  for (const asset of referenced) {
-    if (!fs.existsSync(path.join(publicAssetsDir, asset))) {
-      missing.push(asset);
-    }
-  }
-  if (missing.length) {
-    console.warn('Missing assets: ' + missing.join(', '));
-  }
-}
-
-const referenced = collectReferencedAssets();
 copyAttachedAssets();
-checkMissingAssets(referenced);

--- a/scripts/check-deployment.mjs
+++ b/scripts/check-deployment.mjs
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+
+const API_BASES = (process.env.API_BASES || 'http://localhost:5000,https://your-render-url').split(',');
+const SITE_BASES = (process.env.SITE_BASES || 'http://localhost:5173,https://your-vercel-url').split(',');
+
+const API_ENDPOINTS = ['/api/activities', '/api/health'];
+
+const assetsDir = path.resolve(process.cwd(), 'attached_assets');
+const assetFiles = fs.existsSync(assetsDir) ? fs.readdirSync(assetsDir) : [];
+
+async function checkUrl(url) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error(`${url} -> ${res.status}`);
+    } else {
+      console.log(`${url} OK`);
+    }
+  } catch (err) {
+    console.error(`${url} -> ${err.message}`);
+  }
+}
+
+(async () => {
+  for (const base of API_BASES) {
+    for (const ep of API_ENDPOINTS) {
+      await checkUrl(`${base}${ep}`);
+    }
+  }
+
+  for (const base of SITE_BASES) {
+    for (const file of assetFiles) {
+      await checkUrl(`${base}/attached_assets/${file}`);
+    }
+  }
+})();

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,16 +1,19 @@
 # === Database Configuration ===
+# Connection string for MongoDB Atlas
 MONGODB_URI=<your-mongo-uri>
 
 # === Authentication & Security ===
 SESSION_SECRET=<your-session-secret>
 JWT_SECRET=<your-jwt-secret>
 ADMIN_DEFAULT_PASSWORD=<your-admin-password>
+
+# === CORS ===
 # Comma separated list of allowed frontend URLs
 CLIENT_URL=https://your-vercel-domain
 
 # === Server Configuration ===
 NODE_ENV=production
-# ⚠️ Let hosting services define the PORT dynamically. Do not hardcode 5000.
+# Let hosting providers define PORT automatically
 PORT=
 
 # === WhatsApp Notification (Optional) ===

--- a/server/index.ts
+++ b/server/index.ts
@@ -48,8 +48,11 @@ app.set("trust proxy", 1);
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-// Serve static assets
-app.use("/attached_assets", express.static("attached_assets"));
+// Serve static assets from an absolute path so it works in any deployment
+app.use(
+  "/attached_assets",
+  express.static(path.resolve(__dirname, "../attached_assets"))
+);
 
 // Request logging middleware
 app.use((req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
## Summary
- serve attached assets using an absolute path in Express
- copy root `attached_assets` into `client/public/attached_assets` during build
- add scripts and environment variable samples for deployment checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68937e4a74e88331972f2144a0c15873