### PR TITLE
Refactor imports and update deployment configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,16 +6,15 @@ SESSION_SECRET=<your-session-secret>
 JWT_SECRET=<your-jwt-secret>
 ADMIN_DEFAULT_PASSWORD=<your-admin-password>
 # Comma separated list of allowed frontend URLs
-CLIENT_URL=https://your-vercel-domain,http://localhost:5173
+CLIENT_URL=https://marrakech-dunes.vercel.app,http://localhost:5173
 
 # === Server Configuration ===
 NODE_ENV=production
-# ⚠️ Let hosting services define the PORT dynamically. Do not hardcode 5000.
-PORT=
+PORT=5000
 
 # === Client Configuration ===
 # Production backend URL for the frontend
-VITE_API_URL=https://marrakech-dunes-backend.onrender.com
+VITE_API_URL=https://marrakechdunes.onrender.com
 
 # === WhatsApp Notification (Optional) ===
 WHATSAPP_API_KEY=<your-whatsapp-api-key>

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,2 @@
 # Base URL of the API the frontend should call
-VITE_API_URL=https://marrakech-dunes-backend.onrender.com
+VITE_API_URL=https://marrakechdunes.onrender.com

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,7 +8,6 @@
     
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/render.yaml
+++ b/render.yaml
@@ -7,6 +7,8 @@ services:
         value: <your-mongo-uri>
       - key: SESSION_SECRET
         sync: false
+      - key: JWT_SECRET
+        sync: false
 
       # WhatsApp configuration (optional)
       - key: WHATSAPP_API_KEY
@@ -14,15 +16,15 @@ services:
       - key: ADMIN_DEFAULT_PASSWORD
         sync: false
       - key: CLIENT_URL
-        sync: false
+        value: https://marrakech-dunes.vercel.app,http://localhost:5173
       - key: WHATSAPP_RECEIVERS
         sync: false
       - key: ADMIN_PHONE_YAHIA
         sync: false
       - key: ADMIN_PHONE_NADIA
         sync: false
-      - key: WHATSAPP_RECEIVERS
-        sync: false
+      - key: PORT
+        value: 5000
     disk:
       name: marrakech-assets
       mountPath: /app/attached_assets

--- a/server/.env.example
+++ b/server/.env.example
@@ -9,12 +9,11 @@ ADMIN_DEFAULT_PASSWORD=<your-admin-password>
 
 # === CORS ===
 # Comma separated list of allowed frontend URLs
-CLIENT_URL=https://your-vercel-domain,http://localhost:5173
+CLIENT_URL=https://marrakech-dunes.vercel.app,http://localhost:5173
 
 # === Server Configuration ===
 NODE_ENV=production
-# Let hosting providers define PORT automatically
-PORT=
+PORT=5000
 
 # === WhatsApp Notification (Optional) ===
 WHATSAPP_API_KEY=<your-whatsapp-api-key>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,7 @@ import session from "express-session";
 import MongoStore from "connect-mongo";
 import bcrypt from "bcrypt";
 import { storage } from "./storage.js";
-import { insertBookingSchema, insertReviewSchema, insertActivitySchema } from "./shared/schema.ts";
+import { insertBookingSchema, insertReviewSchema, insertActivitySchema } from "./shared/schema";
 import { whatsappService } from "./whatsapp-service.js";
 import { z, ZodError } from "zod";
 import {

--- a/server/vite.dev.ts
+++ b/server/vite.dev.ts
@@ -24,7 +24,7 @@ export async function setupVite(app: Express, server: Server) {
     return;
   }
 
-  const viteConfig = (await import(path.resolve(__dirname, "../vite.config.ts"))).default;
+  const viteConfig = (await import(path.resolve(__dirname, "../vite.config"))).default;
   const { createServer: createViteServer, createLogger } = await import("vite");
   const viteLogger = createLogger();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "jsx": "preserve",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
     "types": ["node", "vite/client"],

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,9 @@
   "outputDirectory": "client/dist",
   "installCommand": "npm install",
   "framework": "vite",
+  "env": {
+    "VITE_API_URL": "https://marrakechdunes.onrender.com"
+  },
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- remove explicit `.ts` extensions from server imports
- drop `allowImportingTsExtensions` and rely on Node style imports
- update env examples and deployment configs for Render and Vercel

## Testing
- `npm run build --workspace=client && npm run build --workspace=server`
- `curl -I https://marrakechdunes.onrender.com/api/health`
- `curl -I https://marrakech-dunes.vercel.app`


------
https://chatgpt.com/codex/tasks/task_e_6893f063c7188331a8f88307a01be676