### PR TITLE
Serve built client from Express and copy assets for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN npm install --legacy-peer-deps
 COPY . .
 
 # Build frontend and backend
-RUN npm run build --workspace=client && npm run build --workspace=server
+RUN npm run build --workspace=client
+RUN npm run build --workspace=server
 
 # --- Production Stage ---
 FROM node:20-slim AS prod

--- a/scripts/check-attached-assets.cjs
+++ b/scripts/check-attached-assets.cjs
@@ -2,20 +2,28 @@ const fs = require('fs');
 const path = require('path');
 
 const projectRoot = path.resolve(__dirname, '..');
-const attachedDir = path.join(projectRoot, 'attached_assets');
-const publicDir = path.join(projectRoot, 'client', 'public', 'attached_assets');
+const publicRoot = path.join(projectRoot, 'client', 'public');
 
-function copyAttachedAssets() {
-  if (!fs.existsSync(attachedDir)) {
-    console.warn('No attached_assets directory found, skipping copy.');
+/**
+ * Copy a directory into client/public preserving all sub-directories
+ * @param {string} dir name of source directory at repo root
+ */
+function copyDir(dir) {
+  const source = path.join(projectRoot, dir);
+  const target = path.join(publicRoot, dir);
+
+  if (!fs.existsSync(source)) {
+    console.warn(`No ${dir} directory found, skipping copy.`);
     return;
   }
 
-  fs.mkdirSync(publicDir, { recursive: true });
-  for (const file of fs.readdirSync(attachedDir)) {
-    fs.copyFileSync(path.join(attachedDir, file), path.join(publicDir, file));
-  }
-  console.log('Copied attached_assets to client/public/attached_assets');
+  fs.mkdirSync(target, { recursive: true });
+  // fs.cpSync is available in Node 16+ and copies recursively
+  fs.cpSync(source, target, { recursive: true });
+  console.log(`Copied ${dir} to client/public/${dir}`);
 }
 
-copyAttachedAssets();
+// Ensure both assets directories are available to the client build
+for (const dir of ['assets', 'attached_assets']) {
+  copyDir(dir);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -99,10 +99,11 @@ app.use((req: Request, res: Response, next: NextFunction) => {
     await setupVite(app, server);
   } else {
     // Serve client build in production
-    const clientDist = path.resolve(__dirname, "../client/dist");
+    const clientDist = path.resolve(__dirname, "../../client/dist");
     if (fs.existsSync(clientDist)) {
       app.use(express.static(clientDist));
-      app.get("*", (_req, res) => {
+      // Serve index.html for any non-API route (SPA fallback)
+      app.get(/^(?!\/api).*/, (_req, res) => {
         res.sendFile(path.join(clientDist, "index.html"));
       });
     } else {


### PR DESCRIPTION
## Summary
- ensure Docker build runs client and server builds
- serve compiled client/dist from Express in production with non-API catch-all
- copy root assets and attached_assets into client/public before build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d2cb18dc8331bf63d36059b11aed