### PR TITLE
fix: add security-events route, gate logging, fix placeholder, clean gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ docker-data/
 
 # ===== FIXED: DO NOT IGNORE ASSETS FOLDERS =====
 # (You can ignore example images if you want, e.g., *.psd or dummy folders, but NOT your production images!)
+
+# Ignore build-copied public assets
+client/public/assets/*
+client/public/attached_assets/*
+!client/public/assets/.keep

--- a/client/src/hooks/use-security.tsx
+++ b/client/src/hooks/use-security.tsx
@@ -98,8 +98,11 @@ export function SecurityProvider({ children }: { children: ReactNode }) {
       details
     });
 
-    // Send to server for audit logging in production
-    if (process.env.NODE_ENV === 'production') {
+    // Send to server for audit logging when enabled
+    if (
+      process.env.NODE_ENV === 'production' &&
+      process.env.ENABLE_SECURITY_LOGGING === 'true'
+    ) {
       apiRequest('POST', '/api/security-events', {
         event,
         details,

--- a/client/src/pages/booking-fixed.tsx
+++ b/client/src/pages/booking-fixed.tsx
@@ -109,11 +109,9 @@ export default function BookingFixed() {
 
   const numberOfPeople = form.watch("numberOfPeople");
   useEffect(() => {
-    const names = Array(numberOfPeople).fill("").map((_, i) => {
-      const currentValue = form.getValues(`participantNames.${i}`);
-      return { value: currentValue || "" };
-    });
-    // @ts-ignore - react-hook-form expects field objects
+    const names = Array.from({ length: numberOfPeople }, (_, i) =>
+      form.getValues(`participantNames.${i}`) || ""
+    );
     replace(names as any);
   }, [numberOfPeople, replace, form]);
 

--- a/client/src/pages/booking.tsx
+++ b/client/src/pages/booking.tsx
@@ -176,9 +176,9 @@ export default function Booking() {
                                   {t('customerName') || 'Full Name'}
                                 </FormLabel>
                                 <FormControl>
-                                  <Input 
-                                    placeholder={t('customerName') || 'Enter your full name'} 
-                                    {...field} 
+                                  <Input
+                                    placeholder={String(t('customerName') as string)}
+                                    {...field}
                                     className="h-12 text-base border-2 border-gray-200 hover:border-moroccan-gold focus:border-moroccan-gold"
                                   />
                                 </FormControl>

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import express, { type Request, Response, NextFunction, Express } from "express";
 import { registerRoutes } from "./routes.js";
+import securityRoutes from "./routes/security.js";
 import dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
@@ -47,6 +48,8 @@ if (!process.env.SESSION_SECRET) {
 app.set("trust proxy", 1);
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+
+app.use("/api", securityRoutes);
 
 // Serve static assets from an absolute path so it works in any deployment
 app.use(

--- a/server/routes/security.ts
+++ b/server/routes/security.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+const router = Router();
+
+router.post("/security-events", (req, res) => {
+  // Optional: log minimal security events server-side
+  // console.log("[SECURITY]", req.body);
+  res.sendStatus(204); // No Content
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add minimal /api/security-events endpoint
- gate client-side security logging with ENABLE_SECURITY_LOGGING flag
- ensure booking form placeholder is string and normalize participant name defaults
- ignore build-copied assets

## Testing
- `npm run build --workspace=client`
- `npm run build --workspace=server`


------
https://chatgpt.com/codex/tasks/task_e_6895e34ea0148331b4845c6e44bfddbd